### PR TITLE
Fix LPeg precedence for Lua dot operators

### DIFF
--- a/macro/lexer.lua
+++ b/macro/lexer.lua
@@ -53,8 +53,8 @@ function lexer.init ()
             OT = OT + P(ex)
         end
     end
-    local operator = token('operator', OT + P '.' + P '~=' + P '<=' + P '>=' + P '...'
-                                              + P '..' + S '+-*/%^#=<>;:,.{}[]()')
+    local operator = token('operator', OT + '~=' + '<=' + '>=' + '...'
+                                              + '..' + S '+-*/%^#=<>;:,.{}[]()')
     -- identifiers
     local ident = token('iden', idsafe * (idsafe + digit) ^ 0)
 


### PR DESCRIPTION
Hi Steve,

I saw your LuaMacro 2.4 announcement on luarocks-dev:

> This fixes some nasty bugs, some of them on the lexical level (like `fred.dog` being lexed as a single identifier!), and some improvements.

I seem to remember taking this shortcut in my original Lua lexer and indeed, I fixed the same bug in [LXSH](https://github.com/xolox/lua-lxsh). Sorry about that :-). Anyway, I was curious how you changed it and think I found a minor bug in the change: The matching of the `.` operator prevents the `..` operator from ever being matched. Here's the explanation I wrote in the commit message:

> LPeg doesn't have a "longest match is preferred" rule which means that when the LPeg pattern "operator" in the Lua lexer first tries to match the Lua dot operator and then tries to match the double dot operator, the second match can never succeed because the first sub-pattern (the single dot) has already been matched and will be returned as a successful match. Because the single dot is already included in the last sub-pattern (the set of single-character operators) I've just removed the `P '.'` sub-pattern. I also removed the `P` prefixes because they're not needed (as long as an LPeg pattern is on the left side of the long expression of valid multi-character operators).

In the 10 minutes I spend on this I didn't figure out how to install LuaMacro + run the tests (I've not used LuaMacro before), so please run them before merging my change to make sure I didn't break them with my suggested change :-].
