### PR TITLE
getter: peek returns semantically significant tokens by default.

### DIFF
--- a/macro.lua
+++ b/macro.lua
@@ -435,21 +435,22 @@ function M.substitute(src,name, use_c)
 
     local getter = Getter.new(get)
 
-    function getter:peek (k,dont_skip)
-        k = k - 1
-        local token = tok(k)
-        if not token then return nil,'EOS' end
-        local t,v = token[1], token[2]
-        if not dont_skip then
-            local skip = k < 0 and -1 or 1
-            while t == 'space' do
-                k = k + skip
-                token = tok(k)
-                if not tok then return nil,'EOS' end
-                t,v = token[1], token[2]
-            end
-        end
-        return t,v,k+1
+    function getter:peek (offset,dont_skip)
+	local step = offset < 0 and -1 or 1 -- passing offset 0 is undefined
+	local k = 0
+	local token, t, v
+	repeat
+	    while true do
+		token = tok (k)
+		if not token then return nil, 'EOS' end
+		t,v = token[1], token[2]
+	        if dont_skip or (t ~= 'space' and t ~= 'comment') then break end
+		k = k + 1
+	    end
+	    offset = offset - step
+	    k = k + step
+	until offset == 0
+	return t,v,k+1
     end
 
     function getter:peek2 ()


### PR DESCRIPTION
* macro.lua (getter.peek): When `dont_skip` is falsey, peek at
the `offset`th token relative to current position, not counting
space and comment tokens.