### PR TITLE
getter: ipairs over TokenListList does not work with Lua 5.3.

### DIFF
--- a/macro/Getter.lua
+++ b/macro/Getter.lua
@@ -201,7 +201,8 @@ function Getter.names(tok,endt,delim)
     if not ltl then error('get_names: '..err) end
     local names = {}
     -- list() will return {{}} for an empty list of tlists
-    for i,tl in ipairs(ltl) do
+    for i = 1,#ltl do
+	local tl = ltl[i]
         local tv = tl[1]
         if tv then
             if tv[1] == 'space' then tv = tl[2] end


### PR DESCRIPTION
* macro/Getter.lua (Getter.names): Change ipairs invocation to
a numeric loop over indices.