### PR TITLE
macro: don't override callers please_throw preference.

### DIFF
--- a/macro.lua
+++ b/macro.lua
@@ -322,7 +322,7 @@ M.please_throw = false
 --- macro error messages.
 -- @param msg the message: will also have file:line.
 function M.error(msg)
-    msg = M.filename..':'..lexer.line..' '..msg
+    msg = M.filename..':'..lexer.line..': '..msg
     if M.please_throw then
         error(msg,2)
     else

--- a/macro.lua
+++ b/macro.lua
@@ -322,7 +322,6 @@ M.please_throw = false
 --- macro error messages.
 -- @param msg the message: will also have file:line.
 function M.error(msg)
-    M.please_throw = true
     msg = M.filename..':'..lexer.line..' '..msg
     if M.please_throw then
         error(msg,2)


### PR DESCRIPTION
* macro.lua (error): Unconditionally setting `please_throw`
renders the following else clause unreachable, and prevents the
caller from requesting termination on error.