### PR TITLE
refactor: use iden consistently for getting and putting 'iden' tokens.

### DIFF
--- a/macro.lua
+++ b/macro.lua
@@ -129,7 +129,7 @@ function M.define(macstr,subst_fn)
     end
     t = tok()
     if t == '(' then
-        parms = Getter.new(tok):names()
+        parms = Getter.new(tok):idens()
     end
     mtbl[macname] = {
         name = macname,
@@ -463,7 +463,7 @@ function M.substitute(src,name, use_c)
     end
 
     function getter:placeholder (put)
-        put:name '/MARK?/'
+        put:iden '/MARK?/'
         return ii
     end
 

--- a/macro/Getter.lua
+++ b/macro/Getter.lua
@@ -2,8 +2,8 @@
 -- argument `get` of a macro substitution function is of this type.
 --
 --    M.define ('\\',function(get,put)
---        local args, body = get:names('('), get:list()
---        return put:keyword 'function' '(' : names(args) ')' :
+--        local args, body = get:idens('('), get:list()
+--        return put:keyword 'function' '(' : idens(args) ')' :
 --             keyword 'return' : list(body) : space() : keyword 'end'
 --    end)
 --
@@ -174,12 +174,14 @@ end
 
 --- get the next identifier token.
 -- (will be an error if the token has wrong type)
--- @return name
-function Getter.name(tok)
+-- @return identifier name
+function Getter.iden(tok)
     local t,v = tnext(tok)
-    M.assert(t == 'iden','expecting name')
+    M.assert(t == 'iden','expecting identifier')
     return v
 end
+
+Getter.name = Getter.iden -- backwards compatibility!
 
 --- get the next number token.
 -- (will be an error if the token has wrong type)
@@ -190,15 +192,15 @@ function Getter.number(tok)
     return tonumber(v)
 end
 
---- get a delimited list of names.
+--- get a delimited list of identifiers.
 -- works like list.
 -- @param tok the token stream
 -- @param endt the end token (default ')')
 -- @param delim the delimiter (default ',')
 -- @see list
-function Getter.names(tok,endt,delim)
+function Getter.idens(tok,endt,delim)
     local ltl,err = tok:list(endt,delim)
-    if not ltl then error('get_names: '..err) end
+    if not ltl then error('idens: '..err) end
     local names = {}
     -- list() will return {{}} for an empty list of tlists
     for i,tl in ipairs(ltl) do
@@ -210,6 +212,8 @@ function Getter.names(tok,endt,delim)
     end
     return names, err
 end
+
+Getter.names = Getter.idens -- backwards compatibility!
 
 --- get the next string token.
 -- (will be an error if the token has wrong type)

--- a/macro/TokenList.lua
+++ b/macro/TokenList.lua
@@ -43,7 +43,7 @@ local function extract (tl)
 end
 
 --- get an identifier from front of a token list.
--- @return name
+-- @return identifier name
 function TokenList.get_iden (tl)
     local tk = extract(tl)
     M.assert(tk[1]=='iden','expecting identifier')
@@ -95,7 +95,7 @@ local comma,space = {',',','},{'space',' '}
 -- @param name the identifier
 -- @param no_space true if you don't want a space after the iden
 -- @return self
-function TokenList.name(res,name,no_space)
+function TokenList.iden(res,name,no_space)
     append(res,{'iden',name})
     if not no_space then
         append(res,space)
@@ -103,11 +103,13 @@ function TokenList.name(res,name,no_space)
     return res
 end
 
+TokenList.name = TokenList.iden -- backwards compatibility!
+
 --- append a string.
--- @param name the string
+-- @param s the string
 -- @return self
-function TokenList.string(res,name)
-    append(res,{'string','"'..name..'"'})
+function TokenList.string(res,s)
+    append(res,{'string','"'..s..'"'})
     return res
 end
 
@@ -119,21 +121,23 @@ function TokenList.number(res,val)
     return res
 end
 
---- put out a list of names, separated by commas.
+--- put out a list of identifiers, separated by commas.
 -- @param res output token list
--- @param names a list of strings
+-- @param names a list of identifiers
 -- @return self
-function TokenList.names(res,names)
+function TokenList.idens(res,names)
     for i = 1,#names do
-        res:name(names[i],true)
+        res:iden(names[i],true)
         if i ~= #names then append(res,comma) end
     end
     return res
 end
 
+TokenList.names = TokenList.idens -- backwards compatibility!
+
 --- put out a token list.
 -- @param res output token list
--- @param names a token list
+-- @param tl a token list
 -- @return self
 function TokenList.tokens(res,tl)
     for j = 1,#tl do
@@ -144,7 +148,7 @@ end
 
 --- put out a list of token lists, separated by commas.
 -- @param res output token list
--- @param names a list of strings
+-- @param ltl a list of token lists
 -- @return self
 function TokenList.list(res,ltl)
     for i = 1,#ltl do

--- a/macro/forall.lua
+++ b/macro/forall.lua
@@ -21,22 +21,22 @@ local M = require 'macro'
 --- extended for statement.
 -- @macro forall
 M.define('forall',function(get,put)
-    local var = get:name()
+    local var = get:iden()
     local t,v = get:next()
     local rest,endt = get:list(M.upto_keywords('do','if'))
     put:keyword 'for'
     if v == 'in' then
-        put:name '_' ',' :name(var):keyword 'in'
-        put:name 'ipairs' '(' :list(rest) ')'
+        put:iden '_' ',' :iden(var):keyword 'in'
+        put:iden 'ipairs' '(' :list(rest) ')'
     elseif v == '=' then
-        put:name(var) '=' :list(rest)
+        put:iden(var) '=' :list(rest)
     else
         M.error("expecting in or =")
     end
     put:keyword 'do'
     if endt[2] == 'if' then
         rest,endt = get:list(M.upto_keywords('do'))
-        put:keyword 'if':list(rest):keyword 'then':name '_END_END_'
+        put:keyword 'if':list(rest):keyword 'then':iden '_END_END_'
     end
     return put
 end)
@@ -56,15 +56,15 @@ M.define('L',function(get,put)
         return t == '|' or t == 'keyword' and v == 'for'
     end,'')
     local select = get:list('}','')
-    put '(' : keyword 'function' '(' ')' :keyword 'local':name 'res' '=' '{' '}'
+    put '(' : keyword 'function' '(' ')' :keyword 'local':iden 'res' '=' '{' '}'
     if endt[2] == '|' then
-        put:name'forall'
+        put:iden'forall'
     else
         put:keyword 'for'
     end
     put:list(select):space():keyword'do'
-    put:name'res' '[' '#' :name'res' '+' :number(1) ']' '=' :list(expr):space()
-    put:keyword 'end' :keyword 'return' : name 'res' :keyword 'end' ')' '(' ')'
-    put:name '_POP_':string'L'
+    put:iden'res' '[' '#' :iden'res' '+' :number(1) ']' '=' :list(expr):space()
+    put:keyword 'end' :keyword 'return' : iden 'res' :keyword 'end' ')' '(' ')'
+    put:iden '_POP_':string'L'
     return put
 end)

--- a/macro/ifelse.lua
+++ b/macro/ifelse.lua
@@ -33,7 +33,7 @@ end
 M.define('@',function(get,put)
     local t,v = get()
 --~     print('got',t,v)
-    return put:name(v..'_')
+    return put:iden(v..'_')
 end)
 
 local ifstack,push,pop = {},table.insert,table.remove

--- a/macro/lambda.lua
+++ b/macro/lambda.lua
@@ -15,8 +15,8 @@
 local M = require 'macro'
 
 M.define ('\\',function(get,put)
-	local args, body = get:names('('), get:list()
-	return put:keyword 'function' '(' : names(args) ')' :
+	local args, body = get:idens('('), get:list()
+	return put:keyword 'function' '(' : idens(args) ')' :
         keyword 'return' : list(body) : space() : keyword 'end'
 end)
 

--- a/macro/lc.lua
+++ b/macro/lc.lua
@@ -308,7 +308,7 @@ static void $(klass)_register (lua_State *L) {
 ]]
 
 M.define('class',function(get)
-    local name = get:name()
+    local name = get:iden()
     get:expecting '{'
     local fields = get:upto (function(t,v)
         return t == 'iden' and v == 'constructor'

--- a/macro/module.lua
+++ b/macro/module.lua
@@ -93,13 +93,13 @@ local no_class_require
 local function at_handler (get,put)
     local tn,name,tp = get:peek2(1)
     M.assert(tn == 'iden','identifier must follow @')
-    return put:name ('self',true) (tp=='(' and ':' or '.')
+    return put:iden ('self',true) (tp=='(' and ':' or '.')
 end
 
 local function method_handler (get,put)
   local tn,name,tp = get:peek2()
   if not was_local_function(get) and tn == 'iden' and tp == '(' then
-    return put ' ' :name ('_C',true) '.'
+    return put ' ' :iden ('_C',true) '.'
   end
 end
 
@@ -114,10 +114,10 @@ end)
 
 M.define('class',function(get)
     local base = ''
-    local name = get:name()
+    local name = get:iden()
     if get:peek(1) == ':' then
         get:next()
-        base = get:name()
+        base = get:iden()
     end
     module_add_new_local(name)
     return ('do local _C = _class(%s); %s = _C; _C_\n'):format(base,name)

--- a/tests/const.lua
+++ b/tests/const.lua
@@ -1,7 +1,7 @@
 local macro = require 'macro'
 macro.define ('const',function(get)
    get()
-   local vars,values = get:names '=',get:list '\n'
+   local vars,values = get:idens '=',get:list '\n'
    for i,name in ipairs(vars) do
       macro.assert(values[i],'each constant must be assigned!')
       macro.define_scoped(name,tostring(values[i]))

--- a/tests/cskin.lua
+++ b/tests/cskin.lua
@@ -81,16 +81,16 @@ end)
 M.define('def',function(get,put)
     local stuff = get:list('{','')
     put:keyword('function')
-    if btop.classname then put:name(btop.classname) '.' end
+    if btop.classname then put:iden(btop.classname) '.' end
     push_brace_stack()
     return put:list(stuff)
 end)
 
 ----- OOP support ------
 M.define('class',function(get,put)
-    local name,t,v = get:name(),get:next()
+    local name,t,v = get:iden(),get:next()
     local base = ''
-    if t == ':' then base = get:name(); t = get:next() end
+    if t == ':' then base = get:iden(); t = get:next() end
     M.assert(t == '{','expecting {')
     push_brace_stack {classname = name}
     return 'do '..name..' = class_('..base..')'
@@ -110,7 +110,7 @@ M.define('forall',function (get,put)
     stuff = fun(get.from_tl(stuff),put)
     -- let the unskinned Lua pass through with _SKIN_ to re-enable skinning
     disabled = true
-    stuff:name '_SKIN_':space()
+    stuff:iden '_SKIN_':space()
     push_brace_stack()
     return stuff
 end)

--- a/tests/forall1.lua
+++ b/tests/forall1.lua
@@ -1,7 +1,7 @@
 local macro = require 'macro'
 
 macro.define('forall',function(get)
-  local var = get:name()
+  local var = get:iden()
   local t,v = get:next() -- will be 'in'
   local rest = tostring(get:upto 'do')
   return ('for _,%s in ipairs(%s) do'):format(var,rest)

--- a/tests/lc.lua
+++ b/tests/lc.lua
@@ -113,7 +113,7 @@ end)
 
 
 M.define('def',function(get)
-    local fname = get:name()
+    local fname = get:iden()
     local cname = (btop.ns and btop.ns..'_' or '')..fname
     append(btop.names,fname)
     append(btop.cnames,cname)
@@ -263,7 +263,7 @@ static void $(klass)_register (lua_State *L) {
 ]]
 
 M.define('class',function(get)
-    local name = get:name()
+    local name = get:iden()
     get:expecting '{'
     local fields = get:upto (function(t,v)
         return t == 'iden' and v == 'constructor'

--- a/tests/list.lua
+++ b/tests/list.lua
@@ -11,7 +11,7 @@ M.define ('list',function(get)
     -- 'list' acts as a 'type' followed by a variable list, which may be
     -- followed by initial values
     local values
-    local vars,endt = get:names (function(t,v)
+    local vars,endt = get:idens (function(t,v)
         return t == '=' or (t == 'space' and v:find '\n')
     end)
     -- there is an initialization list

--- a/tests/proto.lua
+++ b/tests/proto.lua
@@ -25,7 +25,7 @@ M.define('Function',function(get,put)
     put :space()
     for i,a in ipairs(args) do
         local tp = a:pick(1)
-        put :name('_assert_arg') '(' :name(names[i]) ',' :number(i) ',' :string(tp) ')' ';'
+        put :iden('_assert_arg') '(' :iden(names[i]) ',' :number(i) ',' :string(tp) ')' ';'
     end
     return put
 end)

--- a/tests/rawhash.lua
+++ b/tests/rawhash.lua
@@ -5,7 +5,7 @@ local concat = table.concat
 M.define ('Tab',function(get)
     get() -- skip space
     -- 'Tab' acts as a 'type' followed by a variable list
-    local vars,endt = get:names (function(t,v)
+    local vars,endt = get:idens (function(t,v)
         return t == '=' or (t == 'space' and v:find '\n')
     end)
     local values = {}


### PR DESCRIPTION
* macro/Getter.lua (name, names): Rename from these...
(iden, idens): ...to these.  Adjust all callers.
Keep old method names as aliases for backwards compatibility.
* macro/TokenList.lua (name, names): Rename from these...
(iden, idens): ...to these. Adjust all callers.
Keep old method names as aliases for backwards compatibility.
* readme.md: Adjust accordingly.