### PR TITLE
Getter: fix a symbol-name typo in Getter.scan_iter.

### DIFF
--- a/macro/Getter.lua
+++ b/macro/Getter.lua
@@ -51,7 +51,7 @@ function Getter.scan_iter (tlist)
         if k ~= nil then
             k = i + k
             if k < 1 or k > n then return nil end
-            return tokens[k]
+            return tlist[k]
         end
         local tv = tlist[i]
         if tv == nil then return nil end


### PR DESCRIPTION
* macro/Getter.lua (Getter.scan_iter): Fix a reference to the
token list argument misspelled as `tokens` to `tlist`, the name
of the function argument.